### PR TITLE
Fixed an issue with hent saerlige opplysninger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
-## v.0.1.5 (to be released)
+## v.0.1.6 (to be released)
+
+## v.0.1.5
+* FIXED: Issue with service and hent_saerlige_opplysninger when client returned one line.
 
 ## v.0.1.4
 

--- a/lib/brreg_grunndata/types/factories.rb
+++ b/lib/brreg_grunndata/types/factories.rb
@@ -65,7 +65,9 @@ module BrregGrunndata
       end
 
       def additional_information(lines)
-        Array(lines).map do |line|
+        lines = [lines].compact.flatten
+
+        lines.map do |line|
           AdditionalInformation.new(
             status_code: line[:@statuskode],
             description: line[:tekst_linje],

--- a/lib/brreg_grunndata/version.rb
+++ b/lib/brreg_grunndata/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module BrregGrunndata
-  VERSION = '0.1.4'
+  VERSION = '0.1.5'
 end

--- a/spec/brreg_grunndata/service_spec.rb
+++ b/spec/brreg_grunndata/service_spec.rb
@@ -174,6 +174,28 @@ module BrregGrunndata
           expect(info.status_code).to eq 'R-FR'
           expect(info.description).to eq 'Registrert i Foretaksregisteret'
         end
+
+        it 'returns an organization when only one line of data is returned from API' do
+          expect(filled_saerlige_opplysninger_response)
+            .to receive(:message)
+            .and_return(
+              organisasjonsnummer: '912576108', saerlige_opplysninger: {
+                status: {
+                  tekst_linje: 'Registrert i Foretaksregisteret',
+                  :@registrerings_dato => '2013-10-14',
+                  :@statuskode => 'R-FR'
+                }
+              },
+              :@tjeneste => 'hentSaerligeOpplysninger'
+            )
+
+          organization = subject.hent_saerlige_opplysninger orgnr: '992090936'
+          info = organization.additional_information[0]
+
+          expect(info.registered_date).to eq Date.new(2013, 10, 14)
+          expect(info.status_code).to eq 'R-FR'
+          expect(info.description).to eq 'Registrert i Foretaksregisteret'
+        end
       end
 
       context 'not found' do


### PR DESCRIPTION
Was related to what I think is how savon returns hash structure VS array structure when number of status elements in XML doc is one or many. When it is one we get a hash, when it is many we get array.