### PR TITLE
Upgrade Savon to latest version

### DIFF
--- a/brreg_grunndata.gemspec
+++ b/brreg_grunndata.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'savon', '>= 2.11.1', '< 2.13.0'
+  spec.add_dependency 'savon'
   spec.add_dependency 'dry-struct', '~> 1.0'
   spec.add_dependency 'dry-types', '~> 1.2'
 

--- a/spec/brreg_grunndata/client/response_spec.rb
+++ b/spec/brreg_grunndata/client/response_spec.rb
@@ -12,7 +12,8 @@ module BrregGrunndata
       let(:http) do
         double  'http',
                 body: raw_body,
-                error?: false
+                error?: false,
+                headers: Rack::Headers.new
       end
 
       let(:savon_response) { Savon::Response.new http, globals, locals }


### PR DESCRIPTION
While investigating `HTTPI::SSLError` errors, we tried upgrading savon. However the problem turned out to be with using `HTTPClient`, but it is still worth upgrading anyway.